### PR TITLE
Expose flake inputs to modules

### DIFF
--- a/erich.nix
+++ b/erich.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  inputs,
   ...
 }:
 {

--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,19 @@
     nixos-hardware.url = "github:NixOS/nixos-hardware";
   };
 
-  outputs = { self, nixpkgs, home-manager, nixos-hardware, ... }:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      home-manager,
+      nixos-hardware,
+      ...
+    }:
     {
       nixosConfigurations = {
         apollo = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
+          specialArgs = { inherit inputs; };
           modules = [
             ./machines/apollo.nix
             home-manager.nixosModules.home-manager
@@ -28,6 +36,7 @@
 
         artemis = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
+          specialArgs = { inherit inputs; };
           modules = [
             ./machines/artemis.nix
             home-manager.nixosModules.home-manager
@@ -40,4 +49,3 @@
       };
     };
 }
-


### PR DESCRIPTION
## Summary
- add `inputs` argument to `erich.nix`
- pass flake `inputs` to NixOS systems via `specialArgs`

## Testing
- `nix flake check --extra-experimental-features 'nix-command flakes'` *(fails: The ‘fileSystems’ option does not specify your root file system)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c8595458832aa2936939e9b7e75b