### PR TITLE
Add Hermes SD image build output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,5 +78,10 @@
           ];
         };
       };
+      # Build the Hermes SD image explicitly with:
+      #   nix build .#packages.aarch64-linux.hermes-img
+      packages.aarch64-linux = {
+        hermes-img = self.nixosConfigurations.hermes.config.system.build.sdImage;
+      };
     };
 }

--- a/machines/hermes.nix
+++ b/machines/hermes.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  modulesPath,
   ...
 }:
 {
@@ -9,6 +10,7 @@
     ../erich.nix
     ../modules/remote-build-client.nix
     ../modules/syncthing.nix
+    (modulesPath + "/installer/cd-dvd/sd-image.nix")
   ];
 
   networking.hostName = "hermes";
@@ -66,6 +68,13 @@
         #"--device=/dev/ttyACM0:/dev/ttyACM0"  # Example, change this to match your own hardware
       ];
     };
+  };
+
+  sdImage = {
+    compressImage = false;
+    imageName = "hermes-${config.system.nixos.label}.img";
+    # Build the SD image on demand with:
+    #   nix build .#packages.aarch64-linux.hermes-img
   };
 
   # This value determines the NixOS release from which the default


### PR DESCRIPTION
## Summary
- import the sd-image installer module into the Hermes configuration and disable compression to emit a raw .img
- expose the Hermes SD image through the flake outputs for aarch64-linux builds
- document that the Hermes SD image is built via `nix build .#packages.aarch64-linux.hermes-img`

## Testing
- not run (N/A)

------
https://chatgpt.com/codex/tasks/task_e_69091413eb54832ab89b7a507a811d09