### PR TITLE
Expose nixpkgs-unstable packages via overlay

### DIFF
--- a/erich.nix
+++ b/erich.nix
@@ -55,6 +55,13 @@
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;
   nixpkgs.config.allowUnfreePredicate = _: true;
+  nixpkgs.overlays = [
+    (final: prev: {
+      unstable = import inputs.nixpkgs-unstable {
+        inherit (final) system config;
+      };
+    })
+  ];
 
   # Run unpatched dynamic binaries on NixOS.
   programs.nix-ld.enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## Summary
- add a nixpkgs-unstable input to the flake alongside the stable pin
- expose the unstable package set through an overlay so packages are available as `pkgs.unstable`

## Testing
- not run (nix is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690a564de548832aa9751d27e64bb3c7